### PR TITLE
update prd url endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ SUA_ENDPOINT=https://vzdc.org/api/sua
 CONFLICT_PROBING_DATA_ENDPOINT=http://localhost:8000/data
 CONFLICT_PROBING_CONFIG_ENDPOINT=http://localhost:8000/config
 CONFLICT_PROBING_ATC_DATA_ENDPOINT=http://localhost:8000/atc_data
+CONFLICT_PROBING_PRD_ENDPOINT=http://localhost:8000/prd
 
 TRAINING_MODE=false
 

--- a/actions/prd.ts
+++ b/actions/prd.ts
@@ -1,12 +1,14 @@
 'use server';
 import {PreferredRoute} from "@/types";
 
+const {CONFLICT_PROBING_PRD_ENDPOINT} = process.env;
+
 export async function getRoutes(origin: string, dest?: string) {
     if (!origin) {
         return [];
     }
 
-    const res = await fetch(`https://api.aviationapi.com/v1/preferred-routes/search?origin=${origin}&dest=${dest}`);
+    const res = await fetch(`${CONFLICT_PROBING_PRD_ENDPOINT}?origin=${origin}&dest=${dest}`);
     if (!res.ok) return [];
     const data: PreferredRoute[] = await res.json();
     return data;


### PR DESCRIPTION
This pull request updates how the application retrieves preferred route data by switching from an external API to a configurable local endpoint. The main changes involve introducing a new environment variable and updating the fetch logic to use this variable.

**Configuration changes:**

* Added the `CONFLICT_PROBING_PRD_ENDPOINT` variable to `.env.example` to allow configuration of the preferred routes data source.

**Code changes:**

* Updated `getRoutes` in `actions/prd.ts` to fetch preferred routes from the configurable local endpoint defined by `CONFLICT_PROBING_PRD_ENDPOINT` instead of the external API.